### PR TITLE
Fallback to Text/BinaryMarshaler in ToDriverValue

### DIFF
--- a/internal/globaldata/globaldata.go
+++ b/internal/globaldata/globaldata.go
@@ -4,6 +4,7 @@ import (
 	"database/sql/driver"
 	"encoding"
 	"reflect"
+	"time"
 )
 
 var (
@@ -11,6 +12,8 @@ var (
 	DriverValuerIntf            = reflect.TypeOf((*driver.Valuer)(nil)).Elem()
 	EncodingTextMarshalerIntf   = reflect.TypeOf((*encoding.TextMarshaler)(nil)).Elem()
 	EncodingTextUnmarshalerIntf = reflect.TypeOf((*encoding.TextUnmarshaler)(nil)).Elem()
+	EncodingBinaryMarshalerIntf = reflect.TypeOf((*encoding.BinaryMarshaler)(nil)).Elem()
+	TimeType                    = reflect.TypeOf(time.Time{})
 	Int64Type                   = reflect.TypeOf(int64(0))
 	ByteSliceType               = reflect.TypeOf([]byte(nil))
 )

--- a/value.go
+++ b/value.go
@@ -2,6 +2,7 @@ package opt
 
 import (
 	"database/sql/driver"
+	"encoding"
 	"reflect"
 
 	"github.com/aarondl/opt/internal/globaldata"
@@ -31,6 +32,23 @@ func ToDriverValue(val any) (driver.Value, error) {
 		}
 	case reflect.String:
 		return refVal.String(), nil
+	}
+
+	// If it is of time.Time type, return it as is.
+	if refVal.Type() == globaldata.TimeType {
+		return val, nil
+	}
+
+	// If it implements encoding.TextMarshaler, use that.
+	if refVal.Type().Implements(globaldata.EncodingTextMarshalerIntf) {
+		marshaler := refVal.Interface().(encoding.TextMarshaler)
+		return marshaler.MarshalText()
+	}
+
+	// If it implements encoding.BinaryMarshaler, use that.
+	if refVal.Type().Implements(globaldata.EncodingBinaryMarshalerIntf) {
+		marshaler := refVal.Interface().(encoding.BinaryMarshaler)
+		return marshaler.MarshalBinary()
 	}
 
 	return val, nil

--- a/value.go
+++ b/value.go
@@ -17,23 +17,6 @@ func ToDriverValue(val any) (driver.Value, error) {
 		return valuer.Value()
 	}
 
-	switch refVal.Kind() {
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return refVal.Int(), nil
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		return int64(refVal.Uint()), nil
-	case reflect.Float32, reflect.Float64:
-		return refVal.Float(), nil
-	case reflect.Bool:
-		return refVal.Bool(), nil
-	case reflect.Slice:
-		if refVal.Type().Elem().Kind() == reflect.Uint8 {
-			return refVal.Bytes(), nil
-		}
-	case reflect.String:
-		return refVal.String(), nil
-	}
-
 	// If it is of time.Time type, return it as is.
 	if refVal.Type() == globaldata.TimeType {
 		return val, nil
@@ -49,6 +32,23 @@ func ToDriverValue(val any) (driver.Value, error) {
 	if refVal.Type().Implements(globaldata.EncodingBinaryMarshalerIntf) {
 		marshaler := refVal.Interface().(encoding.BinaryMarshaler)
 		return marshaler.MarshalBinary()
+	}
+
+	switch refVal.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return refVal.Int(), nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return int64(refVal.Uint()), nil
+	case reflect.Float32, reflect.Float64:
+		return refVal.Float(), nil
+	case reflect.Bool:
+		return refVal.Bool(), nil
+	case reflect.Slice:
+		if refVal.Type().Elem().Kind() == reflect.Uint8 {
+			return refVal.Bytes(), nil
+		}
+	case reflect.String:
+		return refVal.String(), nil
 	}
 
 	return val, nil


### PR DESCRIPTION
Since `driver.Value` must be one of

- int64
- float64
- bool
- []byte
- string
- time.Time

This provides a good fallback before resorting to returning the value as-is