### PR TITLE
add Equal methods that work for comparable Vals

### DIFF
--- a/null/null.go
+++ b/null/null.go
@@ -302,3 +302,17 @@ func (v Val[T]) Value() (driver.Value, error) {
 
 	return opt.ToDriverValue(v.value)
 }
+
+// Equal compares two nullable values and returns true if they are equal.
+func Equal[T comparable](a, b Val[T]) bool {
+	if a.state != b.state {
+		return false
+	}
+
+	// states are equal, thus if set, they could have different values
+	if a.state != StateSet {
+		return true
+	}
+
+	return a.value == b.value
+}

--- a/null/null_test.go
+++ b/null/null_test.go
@@ -317,6 +317,31 @@ func TestStateStringer(t *testing.T) {
 	_ = state(99).String()
 }
 
+func TestEqual(t *testing.T) {
+	t.Parallel()
+
+	a := Val[string]{}
+	b := Val[string]{}
+	if !Equal(a, b) {
+		t.Error("should be equal")
+	}
+
+	a.Set("hello")
+	if Equal(a, b) {
+		t.Error("should not be equal")
+	}
+
+	b.Set("hello")
+	if !Equal(a, b) {
+		t.Error("should be equal")
+	}
+
+	b.Set("hi")
+	if Equal(a, b) {
+		t.Error("should not be equal")
+	}
+}
+
 func checkState[T any](t *testing.T, val Val[T], state state) {
 	t.Helper()
 

--- a/omit/omit.go
+++ b/omit/omit.go
@@ -324,3 +324,17 @@ func (v Val[T]) Value() (driver.Value, error) {
 
 	return opt.ToDriverValue(v.value)
 }
+
+// Equal compares two nullable values and returns true if they are equal.
+func Equal[T comparable](a, b Val[T]) bool {
+	if a.state != b.state {
+		return false
+	}
+
+	// states are equal, thus if set, they could have different values
+	if a.state != StateSet {
+		return true
+	}
+
+	return a.value == b.value
+}

--- a/omit/omit_test.go
+++ b/omit/omit_test.go
@@ -329,6 +329,31 @@ func TestStateStringer(t *testing.T) {
 	_ = state(99).String()
 }
 
+func TestEqual(t *testing.T) {
+	t.Parallel()
+
+	a := Val[string]{}
+	b := Val[string]{}
+	if !Equal(a, b) {
+		t.Error("should be equal")
+	}
+
+	a.Set("hello")
+	if Equal(a, b) {
+		t.Error("should not be equal")
+	}
+
+	b.Set("hello")
+	if !Equal(a, b) {
+		t.Error("should be equal")
+	}
+
+	b.Set("hi")
+	if Equal(a, b) {
+		t.Error("should not be equal")
+	}
+}
+
 func checkState[T any](t *testing.T, val Val[T], want state) {
 	t.Helper()
 

--- a/omitnull/omitnull.go
+++ b/omitnull/omitnull.go
@@ -401,3 +401,17 @@ func (v Val[T]) Value() (driver.Value, error) {
 
 	return opt.ToDriverValue(v.value)
 }
+
+// Equal compares two nullable values and returns true if they are equal.
+func Equal[T comparable](a, b Val[T]) bool {
+	if a.state != b.state {
+		return false
+	}
+
+	// states are equal, thus if set, they could have different values
+	if a.state != StateSet {
+		return true
+	}
+
+	return a.value == b.value
+}

--- a/omitnull/omitnull_test.go
+++ b/omitnull/omitnull_test.go
@@ -466,6 +466,46 @@ func TestStateStringer(t *testing.T) {
 	_ = state(99).String()
 }
 
+func TestEqual(t *testing.T) {
+	t.Parallel()
+
+	a := Val[string]{}
+	b := Val[string]{}
+	if !Equal(a, b) {
+		t.Error("should be equal")
+	}
+
+	a.Set("hello")
+	if Equal(a, b) {
+		t.Error("should not be equal")
+	}
+
+	b.Set("hello")
+	if !Equal(a, b) {
+		t.Error("should be equal")
+	}
+
+	b.Set("hi")
+	if Equal(a, b) {
+		t.Error("should not be equal")
+	}
+
+	a.Null()
+	if Equal(a, b) {
+		t.Error("should not be equal")
+	}
+
+	b.Null()
+	if !Equal(a, b) {
+		t.Error("should be equal")
+	}
+
+	a.Unset()
+	if Equal(a, b) {
+		t.Error("should not be equal")
+	}
+}
+
 func checkState[T any](t *testing.T, val Val[T], want state) {
 	t.Helper()
 


### PR DESCRIPTION
Equal method is intuitive, uses Go's comparison semantics, and allows for nice syntactic sugar like `Equal( myNullable, null.FromPtr( myPrimitive ) )` to compare an opt type and a primitive pointer type.